### PR TITLE
Breaking changes: Replace deprecated addContentType method

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class FirestoreSource {
   }
 
   async processCollections(collections, parentDoc = null) {
-    const { slugify, addContentType, getContentType, createReference } = this.store
+    const { slugify, addCollection, getContentType, createReference } = this.store
 
     await Promise.all(collections.map(async (colDef) => {
 
@@ -97,7 +97,7 @@ class FirestoreSource {
         this.verbose && console.log(`Creating content type for ${cName} with ${docs.length} nodes`)
 
         if (!this.cTypes[cName]) {
-          this.cTypes[cName] = addContentType({
+          this.cTypes[cName] = addCollection({
             typeName: cName
           })
         }


### PR DESCRIPTION
As you can see from [Gridsome v.0.7.6 version release changes](https://github.com/gridsome/gridsome/compare/gridsome@0.7.6...master), the method `addContentType()` became deprected and was replaced with `addCollection()` method.

![Screenshot 2019-10-02 at 10 54 13](https://user-images.githubusercontent.com/10692413/66031136-14e93080-e503-11e9-9cf8-f456d198f63f.png)

I tested this change on my project with Gridsome v.0.7.6. Works well, the warning message disappeared.